### PR TITLE
feat: Add configurable Host whitelist to mitigate HNP (Host header po…

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ SDK的使用方法，可以直接查看神策官方文档 https://www.sensorsdat
 
 2.不支持神策的新版本可视化全埋点功能，所以请使用较新SDK的用户，根据神策文档 https://manual.sensorsdata.cn/sa/latest/enable_visualized_autotrack-7548675.html?utm_source=github&utm_campaign=ghost_sa 关闭 可视化全埋点功能，减少报错。
 
+3. **Host whitelist (ALLOWED_HOSTS)**：Configure `ALLOWED_HOSTS` in `configs/admin.py` for Host header validation / canonical host enforcement; empty list = no check (backward compatible). When non-empty, only whitelisted hosts are used for QR and logo URLs. Invalid Host returns 400.
+
 # 更多文档：
 
 接口文档及示例 链接: https://www.apifox.cn/apidoc/shared-48bfd396-858f-442a-b290-5a5a5404ea97  访问密码: gLC6ZUQF

--- a/configs/admin.py
+++ b/configs/admin.py
@@ -79,6 +79,12 @@ admin_password = 'admin' #普通查询密码
 admin_override_code = 'override' #越权密码
 admin_do_not_track_code = 'dntmode' #cdn模式不参与记录密码
 
+# Host header validation (HNP mitigation). When non-empty, QR code and logo URLs only accept these hosts.
+# Validate request.host (authority), not host_url. Comparison is normalized: lowercase, default port (:80/:443) stripped.
+# Empty list = no validation (backward compatible). Example: ['yourdomain.com', 'localhost:8000']
+# If whitelist enabled, invalid Host returns 400.
+ALLOWED_HOSTS = []
+
 
 
 #IP地址转化


### PR DESCRIPTION
# PR Summary

This PR introduces an optional Host whitelist mechanism to mitigate Host header–derived URL poisoning in `show_qrcode` and `show_all_logos`.

Previously, both endpoints generated externally visible URLs using `request.host_url`, which is derived from the inbound HTTP Host header. In deployments where the Host header is not strictly validated at the infrastructure layer, this could allow a forged Host value to be reflected into generated QR code payloads and logo `image_url` fields.

This change adds a configurable allowlist (`ALLOWED_HOSTS`) so that Host validation can be enforced when desired, while preserving full backward compatibility by default.

---

## What This PR Does

### 1. Add configurable Host whitelist

**File:** `configs/admin.py`

- `ALLOWED_HOSTS = []`
- **Default:** empty list → no validation (backward compatible)
- **When non-empty:** only allowlisted hosts are accepted
- Invalid Host values return **HTTP 400**

### 2. Introduce centralized Host validation logic

**File:** `component/api.py`

Two helper functions were added:

- **`_normalize_host(host)`**
- **`_host_validated_base_url()`**

**`_normalize_host`**

- Lowercases host
- Strips trailing dot (e.g. `example.com.` → `example.com`)
- Strips default ports (`:80`, `:443`) for whitelist comparison

**`_host_validated_base_url`**

- Validates `request.host` (authority component)
- Compares against `ALLOWED_HOSTS`
- Returns `request.host_url` only if valid
- Otherwise aborts with **HTTP 400**

### 3. Replace direct `request.host_url` usage

The following endpoints now obtain their base URL via `_host_validated_base_url()`:

- **`show_qrcode`**
- **`show_all_logos`**

No other endpoints were modified.

### 4. Documentation update

**File:** `README.md`

Added documentation for `ALLOWED_HOSTS`, explaining:

- Default behavior
- How to enable Host validation
- 400 response behavior when Host is not allowlisted

---

## Behavior Changes

### Default configuration (`ALLOWED_HOSTS = []`)

- Behavior remains unchanged
- Host-derived URLs are generated as before
- **Fully backward compatible**

### When whitelist is configured

- Only allowlisted Host values are accepted
- Requests with non-allowlisted Host return **HTTP 400**
- Prevents Host header–derived URL poisoning in:
  - QR code payload generation
  - Logo `image_url` generation
